### PR TITLE
Add environment setup helper script

### DIFF
--- a/docs/developer_guide/environment_setup.md
+++ b/docs/developer_guide/environment_setup.md
@@ -24,6 +24,13 @@ The following steps are for UNIX-like systems, and only need to be completed onc
 uv sync --active --all-groups --all-extras
 ```
 
+Alternatively, you can run the helper script to perform the same setup and
+install the pre-commit hook in one step:
+
+```bash
+scripts/setup-env.sh
+```
+
 or
 
 ```bash

--- a/scripts/setup-env.sh
+++ b/scripts/setup-env.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# NautilusTrader environment setup
+#
+# Use uv to install all dependencies and configure environment variables
+# required for building Python extensions.
+#
+# Usage:
+#   source scripts/setup-env.sh
+# or
+#   bash scripts/setup-env.sh
+# (the environment variables will only persist in the current shell if the script
+#  is sourced)
+
+set -e
+
+# Install all dependencies using uv
+uv sync --active --all-groups --all-extras
+
+# Path to the Python interpreter inside the virtual environment
+PYTHON_BIN="$(pwd)/.venv/bin/python"
+
+# Configure PyO3 variables for Rust builds
+LIB_DIR="$($PYTHON_BIN - <<'PY'
+import sysconfig
+print(sysconfig.get_config_var('LIBDIR'))
+PY
+)"
+export LD_LIBRARY_PATH="${LIB_DIR}:${LD_LIBRARY_PATH}"
+export PYO3_PYTHON="${PYTHON_BIN}"
+
+# Install the pre-commit hook
+pre-commit install
+
+echo "Environment setup complete." 


### PR DESCRIPTION
## Summary
- create `scripts/setup-env.sh` for convenient environment bootstrapping
- document helper script in developer guide

## Testing
- `make format`
- `make pre-commit` *(fails: `pre-commit` not installed)*
- `make pytest` *(fails: `ModuleNotFoundError` for `nautilus_trader.core.data`)*
- `make cargo-test` *(fails: returned non-zero exit status)*

------
https://chatgpt.com/codex/tasks/task_e_68559f07b824832bae1175c0bb467635